### PR TITLE
Compatability for gradio web demo

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,12 @@
+import os
+import sys
+sys.path.append(os.getcwd())
+os.environ['ATTN_BACKEND'] = 'xformers'
+os.environ['SPCONV_ALGO'] = 'native' 
+
 import gradio as gr
 from gradio_litmodel3d import LitModel3D
 
-import os
 import shutil
 from typing import *
 import torch

--- a/install.py
+++ b/install.py
@@ -118,6 +118,12 @@ def install_dependencies():
         "Installing diff_gaussian_rasterization from local wheel"
     )
 
+    # install gradio for web app
+    run_command(
+        f"pip install gradio==4.44.1 gradio_litmodel3d==0.0.1",
+        "Installing gradio for web app"
+    )
+
 
 if __name__ == "__main__":
     install_dependencies()


### PR DESCRIPTION
Thanks for your nice work, the one-click installer is really convenient :) 
I have added support for directly running the gradio web application (GUI is more convenient for artists, also can be shared to others)

Other files required :

`run_gradio.bat`
``` powershell 
@echo off
call environment.bat
cd %~dp0trellis-stable-projectorz

if exist trellis_init_completed.txt (
	rem echo Initialization complete. Skipping installation.
) else (
	echo Performing first-time installation. Please wait:
    %PYTHON% -m pip install --upgrade pip
    %PYTHON% install.py
)

rem If all is good, we will eventually create a file which will know us we ran correctly.
rem Next time we do this run.bat, the presence of this file will let us skip pip install in this run.bat
rem
rem Notice the %* at the end of example.py will forward the arguments into example.py
rem For example run.bat --chunk_size 512    will do  example.py --chunk_size 512
%PYTHON% app.py %*

if %ERRORLEVEL% == 0 (
    echo Test script ran successfully. Creating init_completed flag file.
    echo initComplete > trellis_init_completed.txt
)
pause
```

also `ffprobe`  is required for gradio to display the video, place  `ffprobe.exe` under `system/python`

[ffprobe download](https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v6.1/ffprobe-6.1-win-64.zip)

